### PR TITLE
Prepare Release 0.0.2

### DIFF
--- a/custom_components/gruenbeck_cloud/coordinator.py
+++ b/custom_components/gruenbeck_cloud/coordinator.py
@@ -7,6 +7,7 @@ from pygruenbeck_cloud import PyGruenbeckCloud
 from pygruenbeck_cloud.exceptions import (
     PyGruenbeckCloudConnectionClosedError,
     PyGruenbeckCloudError,
+    PyGruenbeckCloudResponseStatusError,
 )
 from pygruenbeck_cloud.models import Device
 
@@ -64,7 +65,10 @@ class GruenbeckCloudCoordinator(DataUpdateCoordinator[Device]):
 
             try:
                 await self.api.listen(callback=self.async_set_updated_data)
-            except PyGruenbeckCloudConnectionClosedError as err:
+            except (
+                PyGruenbeckCloudConnectionClosedError,
+                PyGruenbeckCloudResponseStatusError,
+            ) as err:
                 self.last_update_success = False
                 self.logger.error(err)
             except PyGruenbeckCloudError as err:

--- a/custom_components/gruenbeck_cloud/coordinator.py
+++ b/custom_components/gruenbeck_cloud/coordinator.py
@@ -127,5 +127,6 @@ class GruenbeckCloudCoordinator(DataUpdateCoordinator[Device]):
             self._listen_websocket()
         else:
             await self.api.enter_sd()
+            await self.api.refresh_sd()
 
         return device

--- a/custom_components/gruenbeck_cloud/manifest.json
+++ b/custom_components/gruenbeck_cloud/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/p0l0/hagruenbeck_cloud/issues",
-  "requirements": ["pygruenbeck_cloud==0.0.3"],
+  "requirements": ["pygruenbeck_cloud==0.0.4"],
   "ssdp": [],
   "version": "0.0.2",
   "zeroconf": []

--- a/custom_components/gruenbeck_cloud/manifest.json
+++ b/custom_components/gruenbeck_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/p0l0/hagruenbeck_cloud/issues",
   "requirements": ["pygruenbeck_cloud==0.0.3"],
   "ssdp": [],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "zeroconf": []
 }

--- a/custom_components/gruenbeck_cloud/sensor.py
+++ b/custom_components/gruenbeck_cloud/sensor.py
@@ -28,7 +28,8 @@ from .models import GruenbeckCloudEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
+#@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class GruenbeckCloudEntityDescription(SensorEntityDescription):
     """Describes a Grünbeck Cloud entity."""
 

--- a/custom_components/gruenbeck_cloud/sensor.py
+++ b/custom_components/gruenbeck_cloud/sensor.py
@@ -45,8 +45,8 @@ SENSORS: tuple[GruenbeckCloudEntityDescription, ...] = (
         value_fn=lambda device: device.next_regeneration,
     ),
     GruenbeckCloudEntityDescription(
-        key="last_startup",
-        translation_key="last_startup",
+        key="startup",
+        translation_key="startup",
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda device: device.startup,

--- a/custom_components/gruenbeck_cloud/sensor.py
+++ b/custom_components/gruenbeck_cloud/sensor.py
@@ -28,7 +28,7 @@ from .models import GruenbeckCloudEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-#@dataclass(frozen=True, kw_only=True)
+# @dataclass(frozen=True, kw_only=True)
 @dataclass(kw_only=True)
 class GruenbeckCloudEntityDescription(SensorEntityDescription):
     """Describes a Grünbeck Cloud entity."""

--- a/custom_components/gruenbeck_cloud/strings.json
+++ b/custom_components/gruenbeck_cloud/strings.json
@@ -23,7 +23,7 @@
       "next_regeneration": {
         "name": "Next Regeneration"
       },
-      "last_startup": {
+      "startup": {
         "name": "Start-up date"
       },
       "last_service": {

--- a/custom_components/gruenbeck_cloud/translations/de.json
+++ b/custom_components/gruenbeck_cloud/translations/de.json
@@ -1,0 +1,64 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert"
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "cannot_connect_timeout": "Timeout beim Verbindungsversuch",
+      "unknown": "Unerwarteter Fehler",
+      "no_devices": "Keine Geräte im Account gefunden"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "password": "Passwort",
+          "username": "Benutzername"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "next_regeneration": {
+        "name": "Nächste Regeneration"
+      },
+      "startup": {
+        "name": "Inbetriebsnahmedatum"
+      },
+      "last_service": {
+        "name": "Letzte Wartung"
+      },
+      "raw_water": {
+        "name": "Rohwasserhärte"
+      },
+      "soft_water": {
+        "name": "Weichwasserhärte"
+      },
+      "soft_water_quantity": {
+        "name": "Weichwasserverbrauch"
+      },
+      "regeneration_counter": {
+        "name": "Anzahl Regenerationen"
+      },
+      "current_flow_rate": {
+        "name": "Aktueller Durchfluss"
+      },
+      "remaining_capacity_volume": {
+        "name": "Restkapazität m³"
+      },
+      "remaining_capacity_percentage": {
+        "name": "Restkapazität %"
+      },
+      "salt_range": {
+        "name": "Salzvorrat"
+      },
+      "salt_consumption": {
+        "name": "Salzverbrauch"
+      },
+      "next_service": {
+        "name": "Nächste Wartung"
+      }
+    }
+  }
+}

--- a/custom_components/gruenbeck_cloud/translations/en.json
+++ b/custom_components/gruenbeck_cloud/translations/en.json
@@ -23,7 +23,7 @@
       "next_regeneration": {
         "name": "Next Regeneration"
       },
-      "last_startup": {
+      "startup": {
         "name": "Start-up date"
       },
       "last_service": {

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -15,4 +15,4 @@ ruff==0.1.13
 yamllint==1.33.0
 pydantic==1.10.12
 pylint-per-file-ignores==1.3.2
-pygruenbeck_cloud==0.0.3
+pygruenbeck_cloud==0.0.4


### PR DESCRIPTION
- Bump pygruenbeck_cloud to 0.0.4 (fixes #10, #9)
- Remove Frozen from dataclass (fixes #11)
- Catch PyGruenbeckCloudResponseStatusError to avoid integration crashing (fixes #9)
- Added German translation 
- Renamed sensor "last_startup" to "startup"