### PR TITLE
Release 0.2.0

### DIFF
--- a/custom_components/gruenbeck_cloud/manifest.json
+++ b/custom_components/gruenbeck_cloud/manifest.json
@@ -9,8 +9,10 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/p0l0/hagruenbeck_cloud/issues",
-  "requirements": ["pygruenbeck_cloud==0.1.0"],
+  "requirements": [
+    "pygruenbeck_cloud==0.2.0"
+  ],
   "ssdp": [],
-  "version": "0.1.1",
+  "version": "0.2.0",
   "zeroconf": []
 }

--- a/custom_components/gruenbeck_cloud/manifest.json
+++ b/custom_components/gruenbeck_cloud/manifest.json
@@ -9,9 +9,7 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/p0l0/hagruenbeck_cloud/issues",
-  "requirements": [
-    "pygruenbeck_cloud==0.2.0"
-  ],
+  "requirements": ["pygruenbeck_cloud==0.2.0"],
   "ssdp": [],
   "version": "0.2.0",
   "zeroconf": []

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -15,4 +15,4 @@ ruff==0.6.8
 yamllint==1.35.1
 pydantic==2.9.2
 pylint-per-file-ignores==1.3.2
-pygruenbeck_cloud==0.1.0
+pygruenbeck_cloud==0.2.0


### PR DESCRIPTION
- Bump pygruenbeck_cloud to [0.2.0](https://github.com/p0l0/pygruenbeck_cloud/releases/tag/0.2.0) - (__Fixes #129__)

- Updated testing dependencies:
  - Bump flake8 to 7.1.1
  - Bump pylint to 3.3.0
  - Bump mypy to 1.11.2
  - Bump pre-commit to 3.8.0
  - Bump pytest to 8.3.3
  - Bump pytest-cov to 5.0.0
  - Bump pytest-asyncio to 0.24.0
  - Bump codespell to 2.3.0
  - Bump ruff to 0.6.8
  - Bump yamllint to 1.35.1
  - Bump pydantic to 2.9.2
