### PR TITLE
Prepare Release 1.0.1

### DIFF
--- a/custom_components/gruenbeck_cloud/manifest.json
+++ b/custom_components/gruenbeck_cloud/manifest.json
@@ -9,8 +9,8 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/p0l0/hagruenbeck_cloud/issues",
-  "requirements": ["pygruenbeck_cloud==1.2.0"],
+  "requirements": ["#pygruenbeck_cloud==1.3.0"],
   "ssdp": [],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "zeroconf": []
 }

--- a/custom_components/gruenbeck_cloud/manifest.json
+++ b/custom_components/gruenbeck_cloud/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/p0l0/hagruenbeck_cloud/issues",
-  "requirements": ["#pygruenbeck_cloud==1.3.0"],
+  "requirements": ["pygruenbeck_cloud==1.3.0"],
   "ssdp": [],
   "version": "1.0.1",
   "zeroconf": []

--- a/custom_components/gruenbeck_cloud/sensor.py
+++ b/custom_components/gruenbeck_cloud/sensor.py
@@ -151,21 +151,6 @@ SENSORS: tuple[GruenbeckCloudEntityDescription, ...] = (
             else None
         },
     ),
-    # Perform maintenance in [days]
-    GruenbeckCloudEntityDescription(
-        key="next_service",
-        translation_key="next_service",
-        native_unit_of_measurement=UnitOfTime.DAYS,
-        # device_class=SensorDeviceClass.DURATION,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda device: device.realtime.next_service,
-    ),
-    # Remaining amount / time of current regeneration step
-    GruenbeckCloudEntityDescription(
-        key="regeneration_remaining_time",
-        translation_key="regeneration_remaining_time",
-        value_fn=lambda device: device.realtime.regeneration_remaining_time,
-    ),
     # Regeneration step
     GruenbeckCloudEntityDescription(
         key="regeneration_step",
@@ -181,6 +166,23 @@ SENSORS: tuple[GruenbeckCloudEntityDescription, ...] = (
     # Disabled Entities - Need to be activated manually in Frontend #
     #                                                               #
     #################################################################
+    # Perform maintenance in [days]
+    GruenbeckCloudEntityDescription(
+        key="next_service",
+        translation_key="next_service",
+        entity_registry_enabled_default=False,  # Not available at SE devices
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        # device_class=SensorDeviceClass.DURATION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda device: device.realtime.next_service,
+    ),
+    # Remaining amount / time of current regeneration step
+    GruenbeckCloudEntityDescription(
+        key="regeneration_remaining_time",
+        translation_key="regeneration_remaining_time",
+        entity_registry_enabled_default=False,  # Not available at SE devices
+        value_fn=lambda device: device.realtime.regeneration_remaining_time,
+    ),
     # Soft water exchanger 2 [l]
     GruenbeckCloudEntityDescription(
         key="soft_water_quantity_2",

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -15,4 +15,4 @@ ruff==0.9.1
 yamllint==1.35.1
 pydantic==2.11.5
 pylint-per-file-ignores==1.4.0
-pygruenbeck_cloud==1.2.0
+pygruenbeck_cloud==1.3.0


### PR DESCRIPTION
- Bump pygruenbeck_cloud to 1.3.0 (#117)

⚠️  Sensor "next_service" and "regeneration_remaining_time" are now disabled by default. They seem not to be available on SE Series ⚠️