### PR TITLE
Add state_class to flow sensors for statistics support

### DIFF
--- a/custom_components/gruenbeck_cloud/sensor.py
+++ b/custom_components/gruenbeck_cloud/sensor.py
@@ -115,6 +115,7 @@ SENSORS: tuple[GruenbeckCloudEntityDescription, ...] = (
         translation_key="current_flow_rate",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda device: device.realtime.current_flow_rate,
     ),
     # Soft water Exchanger 1 [m³]
@@ -204,6 +205,7 @@ SENSORS: tuple[GruenbeckCloudEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda device: device.realtime.current_flow_rate_2,
     ),
     # Soft water Exchanger 2 [m³]


### PR DESCRIPTION
## Description

This PR adds `state_class: total_increasing` to flow sensors to enable long-term statistics in Home Assistant.

## Changes

- Added `state_class: total_increasing` to water and salt consumption sensors
- Enables proper tracking in the Energy/Statistics dashboard
- Fixes "Unknown statistics" warning when adding these sensors to device monitoring

## Motivation

Since recent Home Assistant updates, sensors used in the Energy dashboard or device power monitoring require a valid `state_class` to generate statistics. Without this attribute, sensors are rejected with "Unknown statistics selected" warnings.

## Testing

- [ ] Sensors now appear properly in Statistics (Developer Tools → Statistics)
- [ ] No "Unknown statistics" warnings when adding to device monitoring
- [ ] Statistics are being recorded correctly after 5-10 minutes

## Related Issues

Resolves issues with flow sensors not being accepted for statistics tracking in recent HA versions.
